### PR TITLE
support send data to only one subscriber , like queue  支持从众多订阅进程中顺序选择一个发送数据，实现类似于rabbitmq那样的消息队列机制 这只提供一个通讯机制，没有确认、重传机制。

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 namespace Channel;
 
 use Workerman\Connection\AsyncTcpConnection;
-use Workerman\Timer;
+use Workerman\Lib\Timer;
 use Workerman\Protocols\Frame;
 
 /**
@@ -80,7 +80,7 @@ class Client
      * Ping interval.
      * @var int
      */
-    public static $pingInterval = 25;
+    public static $pingInterval = 55;
 
     /**
      * Connect to channel server
@@ -241,7 +241,7 @@ class Client
 
     /**
      * Subscribe.
-     * @param string|string[] $events
+     * @param string $events
      * @return void
      */
     public static function subscribe($events)
@@ -257,7 +257,7 @@ class Client
 
     /**
      * Unsubscribe.
-     * @param string|string[] $events
+     * @param string $events
      * @return void
      */
     public static function unsubscribe($events)
@@ -271,14 +271,15 @@ class Client
 
     /**
      * Publish.
-     * @param string|string[] $events
+     * @param string $events
      * @param mixed $data
      */
-    public static function publish($events, $data)
+    public static function publish($events, $data , $is_loop = false)
     {
-        self::sendAnyway(array('type' => 'publish', 'channels' => (array)$events, 'data' => $data));
+        $type = $is_loop == true ? 'publishLoop' : 'publish';
+        self::sendAnyway(array('type' => $type, 'channels' => (array)$events, 'data' => $data));
     }
-
+    
     /**
      * Watch a channel of queue
      * @param string|array $channels
@@ -323,7 +324,7 @@ class Client
 
     /**
      * Unwatch a channel of queue
-     * @param string|string[] $channels
+     * @param string $channel
      * @throws \Exception
      */
     public static function unwatch($channels)
@@ -339,7 +340,7 @@ class Client
 
 	/**
 	 * Put data to queue
-	 * @param string|string[] $channels
+	 * @param string|array $channels
 	 * @param mixed $data
 	 * @throws \Exception
 	 */

--- a/src/Server.php
+++ b/src/Server.php
@@ -120,6 +120,20 @@ class Server
                     }
                 }
                 break;
+	   case 'publishLoop':
+                //choose one subscriber from the list to send
+                foreach ($data['channels'] as $channel) {
+                    if (empty($worker->channels[$channel])) {
+                        continue;
+                    }
+                    $buffer = serialize(array('type' => 'event', 'channel' => $channel, 'data' => $data['data']))."\n";
+                    $connection = next($worker->channels[$channel]);
+                    if( $connection == false ){
+                        $connection = reset($worker->channels[$channel]);
+                    }
+                    $connection->send($buffer);
+                }
+                break;
             case 'watch':
             	foreach ($data['channels'] as $channel) {
 		            $this->getQueue($channel)->addWatch($connection);

--- a/src/Server.php
+++ b/src/Server.php
@@ -120,13 +120,15 @@ class Server
                     }
                 }
                 break;
-	   case 'publishLoop':
-                //choose one subscriber from the list to send
+            case 'publishLoop':
+                //choose one subscriber from the list
                 foreach ($data['channels'] as $channel) {
                     if (empty($worker->channels[$channel])) {
                         continue;
                     }
                     $buffer = serialize(array('type' => 'event', 'channel' => $channel, 'data' => $data['data']))."\n";
+
+                    //这是要点，每次取出一个元素，如果取不到，说明已经到最后，重置到第一个
                     $connection = next($worker->channels[$channel]);
                     if( $connection == false ){
                         $connection = reset($worker->channels[$channel]);

--- a/test/start_channel.php
+++ b/test/start_channel.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Administrator
+ * Date: 2022/2/20
+ * Time: 12:00
+ */
+
+include_once __DIR__ . '/vendor/autoload.php';
+
+use Workerman\Worker;
+
+$processName = "ChannelServerTest";
+Worker::$pidFile = "var/{$processName}.pid";
+Worker::$logFile = "var/{$processName}_logFile.log";
+Worker::$stdoutFile = "var/{$processName}_stdout.log";
+
+$channel_server = new Channel\Server('0.0.0.0', 2206);
+
+if(!defined('GLOBAL_START'))
+{
+    Worker::runAll();
+}

--- a/test/start_client.php
+++ b/test/start_client.php
@@ -8,9 +8,6 @@ use Workerman\Connection\TcpConnection;
 use Workerman\Connection\AsyncUdpConnection;
 use Workerman\Connection\AsyncTcpConnection;
 
-// 设置每个连接接收的数据包最大为1024000字节
-TcpConnection::$defaultMaxPackageSize = 1024*1024*500;   //500M
-
 //监听端口
 $worker = new Worker("");
 
@@ -20,7 +17,6 @@ $processName = "client";
 $worker->name = $processName;
 $worker->reusePort = true;   //开启均衡负载模式
 
-$date = date("Y-m-d");
 Worker::$pidFile = "var/{$processName}.pid";
 Worker::$logFile = "var/{$processName}_logFile.log";
 Worker::$stdoutFile = "var/{$processName}_stdout.log";

--- a/test/start_client.php
+++ b/test/start_client.php
@@ -1,0 +1,38 @@
+<?php
+
+include_once __DIR__ . '/vendor/autoload.php';
+
+use Workerman\Worker;
+use Workerman\Lib\Timer;
+use Workerman\Connection\TcpConnection;
+use Workerman\Connection\AsyncUdpConnection;
+use Workerman\Connection\AsyncTcpConnection;
+
+// 设置每个连接接收的数据包最大为1024000字节
+TcpConnection::$defaultMaxPackageSize = 1024*1024*500;   //500M
+
+//监听端口
+$worker = new Worker("");
+
+//开启进程数量
+$worker->count = 8;
+$processName = "client";
+$worker->name = $processName;
+$worker->reusePort = true;   //开启均衡负载模式
+
+$date = date("Y-m-d");
+Worker::$pidFile = "var/{$processName}.pid";
+Worker::$logFile = "var/{$processName}_logFile.log";
+Worker::$stdoutFile = "var/{$processName}_stdout.log";
+
+$worker->onWorkerStart = function() use($worker){
+    usleep(10);
+    Channel\Client::connect('127.0.0.1' , 2206);
+    $event_name = "test_channel";
+    Channel\Client::on($event_name, function($event_data)use($worker ,$event_name ){
+        $log_str = "{$worker->id} on {$event_name}:".json_encode($event_data,320)."\n";
+        echo $log_str;
+    });
+};
+
+Worker::runAll();

--- a/test/start_send.php
+++ b/test/start_send.php
@@ -17,7 +17,6 @@ $processName = "send";
 $worker->name = $processName;
 $worker->reusePort = true;   //开启均衡负载模式
 
-$date = date("Y-m-d");
 Worker::$pidFile = "var/{$processName}.pid";
 Worker::$logFile = "var/{$processName}_logFile.log";
 Worker::$stdoutFile = "var/{$processName}_stdout.log";
@@ -30,8 +29,7 @@ $worker->onWorkerStart = function() use($worker){
             'date' => date("Y-m-d H:i:s"),
         ];
         $event_name = "test_channel";
-        Channel\Client::publishLoop($event_name, $data_arr);
-        //echo microtime(true)."\n";
+        Channel\Client::publish($event_name, $data_arr , true);
     });
 };
 Worker::runAll();

--- a/test/start_send.php
+++ b/test/start_send.php
@@ -1,0 +1,37 @@
+<?php
+
+include_once __DIR__ . '/vendor/autoload.php';
+
+use Workerman\Worker;
+use Workerman\Lib\Timer;
+use Workerman\Connection\TcpConnection;
+use Workerman\Connection\AsyncUdpConnection;
+use Workerman\Connection\AsyncTcpConnection;
+
+//监听端口
+$worker = new Worker("");
+
+//开启进程数量
+$worker->count = 1;
+$processName = "send";
+$worker->name = $processName;
+$worker->reusePort = true;   //开启均衡负载模式
+
+$date = date("Y-m-d");
+Worker::$pidFile = "var/{$processName}.pid";
+Worker::$logFile = "var/{$processName}_logFile.log";
+Worker::$stdoutFile = "var/{$processName}_stdout.log";
+
+$worker->onWorkerStart = function() use($worker){
+    Channel\Client::connect('127.0.0.1' , 2206);
+    Timer::add( 1 , function ()use($worker){
+        $data_arr = [
+            'time' => microtime(true),
+            'date' => date("Y-m-d H:i:s"),
+        ];
+        $event_name = "test_channel";
+        Channel\Client::publishLoop($event_name, $data_arr);
+        //echo microtime(true)."\n";
+    });
+};
+Worker::runAll();


### PR DESCRIPTION
choose one subscriber from the list to send
support send data to only one subscriber , like queue 
支持从众多订阅进程中顺序选择一个发送数据，实现类似于rabbitmq那样的消息队列机制
这只提供一个通讯机制，没有确认、重传机制。
修改心跳时间为55秒，更符合互联网环境使用。